### PR TITLE
updated with more support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,8 @@ RUN apk add $APK_OPTS \
   xxd \
   xz-dev xz-static \
   python3 py3-packaging \
-  linux-headers \
   libdrm-dev
 
-# linux-headers need by rtmpdump
 # python3 py3-packaging needed by glib
 
 # -O3 makes sure we compile with optimization. setting CFLAGS/CXXFLAGS seems to override
@@ -168,32 +166,6 @@ RUN if [ "$DECODE_ONLY" = "true" ]; then \
     make -j$(nproc) install; \
   fi
 
-# fdk-aac (encoder)
-COPY [ "src/fdk-aac-*", "./fdk-aac" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping fdk-aac build"; \
-  else \
-    cd fdk-aac && \
-    ./autogen.sh && \
-    ./configure \
-      --disable-shared \
-      --enable-static && \
-    make -j$(nproc) install; \
-  fi
-
-# Remove kvazaar (HEVC encoder)
-COPY [ "src/kvazaar-*", "./kvazaar" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping kvazaar build"; \
-  else \
-    cd kvazaar && \
-    ./autogen.sh && \
-    ./configure \
-      --disable-shared \
-      --enable-static && \
-    make -j$(nproc) install; \
-  fi
-
 # Remove lame (MP3 encoder)
 COPY [ "src/lame-*", "./lame" ]
 RUN if [ "$DECODE_ONLY" = "true" ]; then \
@@ -218,18 +190,6 @@ RUN cd lcms2 && \
     --disable-shared && \
   make -j$(nproc) install
 
-# Remove opencore-amr (niche audio)
-COPY [ "src/opencore-amr-*", "./opencore-amr" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping opencore-amr build"; \
-  else \
-    cd opencore-amr && \
-    ./configure \
-      --enable-static \
-      --disable-shared && \
-    make -j$(nproc) install; \
-  fi
-
 # Keep openjpeg (JPEG 2000 decoder)
 COPY [ "src/openjpeg-*", "./openjpeg" ]
 RUN cd openjpeg && \
@@ -246,46 +206,6 @@ RUN cd openjpeg && \
     .. && \
   make -j$(nproc) install
 
-# Keep opus (decoder)
-COPY [ "src/opus-*", "./opus" ]
-RUN cd opus && \
-  ./configure \
-    --disable-shared \
-    --enable-static \
-    --disable-extra-programs \
-    --disable-doc && \
-  make -j$(nproc) install
-
-# Remove rabbitmq-c (networking)
-COPY [ "src/rabbitmq-c-*", "./rabbitmq-c" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping rabbitmq-c build"; \
-  else \
-    cd rabbitmq-c && \
-    mkdir build && cd build && \
-    cmake \
-      -G"Unix Makefiles" \
-      -DCMAKE_VERBOSE_MAKEFILE=ON \
-      -DBUILD_EXAMPLES=OFF \
-      -DBUILD_SHARED_LIBS=OFF \
-      -DBUILD_STATIC_LIBS=ON \
-      -DCMAKE_INSTALL_PREFIX=/usr/local \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_TESTS=OFF \
-      -DBUILD_TOOLS=OFF \
-      -DBUILD_TOOLS_DOCS=OFF \
-      -DRUN_SYSTEM_TESTS=OFF \
-      .. && \
-    make -j$(nproc) install; \
-  fi
-
-# Remove rtmpdump (networking)
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping rtmpdump build"; \
-  else \
-    apk add $APK_OPTS rtmpdump-dev rtmpdump-static; \
-  fi
 
 # Remove rubberband (audio processing)
 COPY [ "src/rubberband-*", "./rubberband" ]
@@ -299,55 +219,6 @@ RUN if [ "$DECODE_ONLY" = "true" ]; then \
       -Dresampler=libsamplerate && \
     ninja -j$(nproc) -vC build install && \
     echo "Requires.private: fftw3 samplerate" >> /usr/local/lib/pkgconfig/rubberband.pc; \
-  fi
-
-
-# Remove speex (voice codec)
-COPY [ "src/speex-*", "./speex" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping speex build"; \
-  else \
-    cd speex && \
-    ./autogen.sh && \
-    ./configure \
-      --disable-shared \
-      --enable-static && \
-    make -j$(nproc) install; \
-  fi
-
-# Remove libssh (networking)
-COPY [ "src/libssh-*", "./libssh" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "DECODE_ONLY is true, skipping libssh build"; \
-  else \
-    cd libssh && \
-    mkdir build && cd build && \
-    echo -e 'Requires.private: libssl libcrypto zlib \nLibs.private: -DLIBSSH_STATIC=1 -lssh\nCflags.private: -DLIBSSH_STATIC=1 -I${CMAKE_INSTALL_FULL_INCLUDEDIR}' >> ../libssh.pc.cmake && \
-    cmake \
-      -G"Unix Makefiles" \
-      -DCMAKE_VERBOSE_MAKEFILE=ON \
-      -DCMAKE_SYSTEM_ARCH=$(arch) \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DPICKY_DEVELOPER=ON \
-      -DBUILD_STATIC_LIB=ON \
-      -DBUILD_SHARED_LIBS=OFF \
-      -DWITH_GSSAPI=OFF \
-      -DWITH_BLOWFISH_CIPHER=ON \
-      -DWITH_SFTP=ON \
-      -DWITH_SERVER=OFF \
-      -DWITH_ZLIB=ON \
-      -DWITH_PCAP=ON \
-      -DWITH_DEBUG_CRYPTO=OFF \
-      -DWITH_DEBUG_PACKET=OFF \
-      -DWITH_DEBUG_CALLTRACE=OFF \
-      -DUNIT_TESTING=OFF \
-      -DCLIENT_TESTING=OFF \
-      -DSERVER_TESTING=OFF \
-      -DWITH_EXAMPLES=OFF \
-      -DWITH_INTERNAL_DOC=OFF \
-      .. && \
-    make install; \
   fi
 
 # SVT-AV1 (AV1 encoder)
@@ -539,39 +410,8 @@ RUN cd dav1d && \
     -Ddefault_library=static && \
   ninja -j$(nproc) -vC build install
 
-# Remove game-music-emu (niche audio)
-COPY [ "src/game-music-emu", "./game-music-emu" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping game-music-emu build"; \
-  else \
-    cd game-music-emu && \
-    mkdir build && cd build && \
-    cmake \
-      -G"Unix Makefiles" \
-      -DCMAKE_VERBOSE_MAKEFILE=ON \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=OFF \
-      -DENABLE_UBSAN=OFF \
-      .. && \
-    make -j$(nproc) install; \
-  fi
-
-# libmodplug (niche audio)
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping libmodplug build"; \
-  else \
-    apk add $APK_OPTS libmodplug-dev libmodplug-static; \
-  fi
-
 # rav1e (AV1 encoder)
 RUN apk add $APK_OPTS rav1e-static rav1e-dev
-
-# zeromq (networking)
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-    echo "Skipping zeromq build"; \
-  else \
-    apk add zeromq-dev libzmq-static; \
-  fi
 
 # Keep zimg (image processing for decode, scaling etc.)
 COPY [ "src/zimg-*", "./zimg" ]
@@ -581,30 +421,6 @@ RUN cd zimg && \
     --disable-shared \
     --enable-static && \
   make -j$(nproc) install
-
-# srt (networking)
-COPY [ "src/srt-*", "./srt" ]
-RUN if [ "$DECODE_ONLY" = "true" ]; then \
-  echo "DECODE_ONLY is true, skipping srt build"; \
-  else \
-    cd srt && \
-    mkdir build && cd build && \
-    cmake \
-      -G"Unix Makefiles" \
-      -DCMAKE_VERBOSE_MAKEFILE=ON \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DENABLE_SHARED=OFF \
-      -DENABLE_APPS=OFF \
-      -DENABLE_CXX11=ON \
-      -DUSE_STATIC_LIBSTDCXX=ON \
-      -DOPENSSL_USE_STATIC_LIBS=ON \
-      -DENABLE_LOGGING=OFF \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DCMAKE_INSTALL_INCLUDEDIR=include \
-      -DCMAKE_INSTALL_BINDIR=bin \
-      .. && \
-    make -j$(nproc) && make install; \
-  fi
 
 # libwebp (decoder)
 RUN apk add $APK_OPTS libwebp-dev libwebp-static
@@ -645,35 +461,25 @@ RUN cd ffmpeg && \
     FEATURES="$FEATURES --enable-libvvenc"; \
     FEATURES="$FEATURES --enable-libbluray"; \
     FEATURES="$FEATURES --enable-libdavs2"; \
-    FEATURES="$FEATURES --enable-libgme"; \
     # For the GSM audio codec, used in telephony.
     #FEATURES="$FEATURES --enable-libgsm"; \
-    FEATURES="$FEATURES --enable-libmodplug"; \
     # 3d audio support.
-    #FEATURES="$FEATURES --enable-libmysofa"; \
+    FEATURES="$FEATURES --enable-libmysofa"; \
     # AMR audio codecs for mobile.
-    #FEATURES="$FEATURES --enable-libopencore-amrnb --enable-libopencore-amrwb"; \
-    #FEATURES="$FEATURES --enable-librtmp"; \
     # High-quality audio pitch shifting.
     #FEATURES="$FEATURES --enable-librubberband"; \
     # libmp3lame is superior and already included.
     #FEATURES="$FEATURES --enable-libshine"; \
     # Voice audio codec, largely replaced by Opus.
-    #FEATURES="$FEATURES --enable-libspeex"; \
     #FEATURES="$FEATURES --enable-libtheora"; \
-    #FEATURES="$FEATURES --enable-libtwolame"; \
+    FEATURES="$FEATURES --enable-libtwolame"; \
     FEATURES="$FEATURES --enable-libuavs3d"; \
     # Video stabilization filter.
-    #FEATURES="$FEATURES --enable-libvidstab"; \
+    FEATURES="$FEATURES --enable-libvidstab"; \
     FEATURES="$FEATURES --enable-libvmaf"; \
     FEATURES="$FEATURES --enable-libvo-amrwbenc"; \
-    #FEATURES="$FEATURES --enable-libjxl"; \
-    #FEATURES="$FEATURES --enable-librsvg"; \
-    FEATURES="$FEATURES --enable-librabbitmq"; \
-    FEATURES="$FEATURES --enable-libsrt"; \
-    FEATURES="$FEATURES --enable-libssh"; \
-    #FEATURES="$FEATURES --enable-libzmq"; \
-    FEATURES="$FEATURES --enable-libkvazaar"; \
+    FEATURES="$FEATURES --enable-libjxl"; \
+    FEATURES="$FEATURES --enable-librsvg"; \
     FEATURES="$FEATURES --enable-libmp3lame"; \
     #FEATURES="$FEATURES --enable-libshine"; \
     # replaced by x264
@@ -686,6 +492,8 @@ RUN cd ffmpeg && \
     --extra-cxxflags="$CXXFLAGS" \
     --extra-ldexeflags="-fPIE -static-pie" \
     --enable-small \
+    --enable-vulkan \
+    --enable-libplacebo \
     --enable-openssl \
     --disable-shared \
     --disable-ffplay \
@@ -704,92 +512,16 @@ RUN cd ffmpeg && \
     --enable-libwebp \
     --enable-libxml2 \
     --enable-libdav1d \
-    #--enable-libass \
-    #--enable-libfreetype \
-    #--enable-libfribidi \
-    #--enable-libharfbuzz \
-    #--enable-libsoxr \
+    --enable-libass \
+    --enable-libfreetype \
+    --enable-libfribidi \
+    --enable-libharfbuzz \
+    --enable-libsoxr \
     --enable-libopenjpeg \
     --enable-libsnappy \
-    $FEATURES \
+  $FEATURES \
   || (cat ffbuild/config.log ; false) && \
   make -j$(nproc) install
-
-RUN \
-  EXPAT_VERSION=$(pkg-config --modversion expat) \
-  FFTW_VERSION=$(pkg-config --modversion fftw3) \
-  FONTCONFIG_VERSION=$(pkg-config --modversion fontconfig) \
-  FREETYPE_VERSION=$(pkg-config --modversion freetype2) \
-  FRIBIDI_VERSION=$(pkg-config --modversion fribidi) \
-  LIBSAMPLERATE_VERSION=$(pkg-config --modversion samplerate) \
-  LIBVO_AMRWBENC_VERSION=$(pkg-config --modversion vo-amrwbenc) \
-  LIBXML2_VERSION=$(pkg-config --modversion libxml-2.0) \
-  OPENSSL_VERSION=$(pkg-config --modversion openssl) \
-  SNAPPY_VERSION=$(apk info -a snappy $APK_OPTS | head -n1 | awk '{print $1}' | sed -e 's/snappy-//') \
-  SOXR_VERSION=$(pkg-config --modversion soxr) \
-  jq -n \
-  '{ \
-  expat: env.EXPAT_VERSION, \
-  "libfdk-aac": env.FDK_AAC_VERSION, \
-  ffmpeg: env.FFMPEG_VERSION, \
-  fftw: env.FFTW_VERSION, \
-  fontconfig: env.FONTCONFIG_VERSION, \
-  lcms2: env.LCMS2_VERSION, \
-  libaom: env.AOM_VERSION, \
-  libaribb24: env.LIBARIBB24_VERSION, \
-  libass: env.LIBASS_VERSION, \
-  libbluray: env.LIBBLURAY_VERSION, \
-  libdav1d: env.DAV1D_VERSION, \
-  libdavs2: env.DAVS2_VERSION, \
-  libfreetype: env.FREETYPE_VERSION, \
-  libfribidi: env.FRIBIDI_VERSION, \
-  libgme: env.LIBGME_COMMIT, \
-  libgsm: env.LIBGSM_COMMIT, \
-  libharfbuzz: env.LIBHARFBUZZ_VERSION, \
-  libjxl: env.LIBJXL_VERSION, \
-  libkvazaar: env.KVAZAAR_VERSION, \
-  libmodplug: env.LIBMODPLUG_VERSION, \
-  libmp3lame: env.MP3LAME_VERSION, \
-  libmysofa: env.LIBMYSOFA_VERSION, \
-  libogg: env.OGG_VERSION, \
-  libopencoreamr: env.OPENCOREAMR_VERSION, \
-  libopenjpeg: env.OPENJPEG_VERSION, \
-  libopus: env.OPUS_VERSION, \
-  librabbitmq: env.LIBRABBITMQ_VERSION, \
-  librav1e: env.RAV1E_VERSION, \
-  librsvg: env.LIBRSVG_VERSION, \
-  librtmp: env.LIBRTMP_COMMIT, \
-  librubberband: env.RUBBERBAND_VERSION, \
-  libsamplerate: env.LIBSAMPLERATE_VERSION, \
-  #libshine: env.LIBSHINE_VERSION, \
-  libsnappy: env.SNAPPY_VERSION, \
-  libsoxr: env.SOXR_VERSION, \
-  #libspeex: env.SPEEX_VERSION, \
-  libsrt: env.SRT_VERSION, \
-  libssh: env.LIBSSH_VERSION, \
-  libsvtav1: env.SVTAV1_VERSION, \
-  libtheora: env.THEORA_VERSION, \
-  libtwolame: env.TWOLAME_VERSION, \
-  libuavs3d: env.UAVS3D_COMMIT, \
-  libva: env.LIBVA_VERSION, \
-  libvidstab: env.VIDSTAB_VERSION, \
-  libvmaf: env.VMAF_VERSION, \
-  libvo_amrwbenc: env.LIBVO_AMRWBENC_VERSION, \
-  libvorbis: env.VORBIS_VERSION, \
-  libvpl: env.LIBVPL_VERSION, \
-  libvpx: env.VPX_VERSION, \
-  libvvenc: env.VVENC_VERSION, \
-  libwebp: env.LIBWEBP_VERSION, \
-  libx264: env.X264_VERSION, \
-  libx265: env.X265_VERSION, \
-  libxevd: env.XEVD_VERSION, \
-  libxeve: env.XEVE_VERSION, \
-  libxml2: env.LIBXML2_VERSION, \
-  #libxvid: env.XVID_VERSION, \
-  libzimg: env.ZIMG_VERSION, \
-  libzmq: env.LIBZMQ_VERSION, \
-  openssl: env.OPENSSL_VERSION, \
-  }' > /versions.json
 
 # make sure binaries has no dependencies, is relro, pie and stack nx
 COPY checkelf /

--- a/fetch-sources.sh
+++ b/fetch-sources.sh
@@ -178,30 +178,6 @@ fetch_and_unpack srt SRT_VERSION SRT_URL SRT_SHA256
 : "${ZIMG_SHA256:=a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf}"
 fetch_and_unpack zimg ZIMG_VERSION ZIMG_URL ZIMG_SHA256
 
-# bump: libzmq /LIBZMQ_VERSION=([\d.]+)/ https://github.com/zeromq/libzmq.git|*
-# bump: libzmq after ./hashupdate Dockerfile LIBZMQ $LATEST
-# bump: libzmq link "NEWS" https://github.com/zeromq/libzmq/blob/master/NEWS
-#: "${LIBZMQ_VERSION:=4.3.5}"
-#: "${LIBZMQ_URL:=https://github.com/zeromq/libzmq/releases/download/v${LIBZMQ_VERSION}/zeromq-$#{LIBZMQ_VERSION}.tar.gz}"
-#: "${LIBZMQ_SHA256:=6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43}"
-#fetch_and_unpack zeromq LIBZMQ_VERSION LIBZMQ_URL LIBZMQ_SHA256
-
-# bump: libgme /LIBGME_COMMIT=([[:xdigit:]]+)/ gitrefs:https://github.com/libgme/game-music-emu.git|re:#^refs/heads/master$#|@commit
-# bump: libgme after ./hashupdate Dockerfile LIBGME $LATEST
-# bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
-: "${LIBGME_URL:=https://github.com/libgme/game-music-emu.git}"
-: "${LIBGME_COMMIT:=9762cbcff3d2224ee0f8b8c41ec143e956ebad56}"
-fetch_and_unpack_git game-music-emu "" LIBGME_URL "" LIBGME_COMMIT
-
-# bump: libmodplug /LIBMODPLUG_VERSION=([\d.]+)/ fetch:https://sourceforge.net/projects/modplug-xmms/files/|/libmodplug-([\d.]+).tar.gz/
-# bump: libmodplug after ./hashupdate Dockerfile LIBMODPLUG $LATEST
-# bump: libmodplug link "NEWS" https://sourceforge.net/p/modplug-xmms/git/ci/master/tree/libmodplug/NEWS
-#: "${LIBMODPLUG_VERSION:=0.8.9.0}"
-#: "${LIBMODPLUG_URL:=https://downloads.sourceforge.net/modplug-xmms/libmodplug-${LIBMODPLUG_VERSION}.tar.gz}"
-#: "${LIBMODPLUG_SHA256:=457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de}"
-#fetch_and_unpack libmodplug LIBMODPLUG_VERSION LIBMODPLUG_URL LIBMODPLUG_SHA256
-
-
 # preferring rav1e-static rav1e-dev from apk (0.7.1)
 # bump: rav1e /RAV1E_VERSION=([\d.]+)/ https://github.com/xiph/rav1e.git|/\d+\./|*
 # bump: rav1e after ./hashupdate Dockerfile RAV1E $LATEST
@@ -280,14 +256,6 @@ fetch_and_unpack libbluray LIBBLURAY_VERSION LIBBLURAY_URL LIBBLURAY_SHA256
 : "${LIBASS_URL:=https://github.com/libass/libass/releases/download/$LIBASS_VERSION/libass-$LIBASS_VERSION.tar.gz}"
 : "${LIBASS_SHA256:=da7c348deb6fa6c24507afab2dee7545ba5dd5bbf90a137bfe9e738f7df68537}"
 fetch_and_unpack libass LIBASS_VERSION LIBASS_URL LIBASS_SHA256
-
-# bump: kvazaar /KVAZAAR_VERSION=([\d.]+)/ https://github.com/ultravideo/kvazaar.git|^2
-# bump: kvazaar after ./hashupdate Dockerfile KVAZAAR $LATEST
-# bump: kvazaar link "Release notes" https://github.com/ultravideo/kvazaar/releases/tag/v$LATEST
-: "${KVAZAAR_VERSION:=2.3.1}"
-: "${KVAZAAR_URL:=https://github.com/ultravideo/kvazaar/archive/v$KVAZAAR_VERSION.tar.gz}"
-: "${KVAZAAR_SHA256:=c5a1699d0bd50bc6bdba485b3438a5681a43d7b2c4fd6311a144740bfa59c9cc}"
-fetch_and_unpack kvazaar KVAZAAR_VERSION KVAZAAR_URL KVAZAAR_SHA256
 
 # bump: libvpl /LIBVPL_VERSION=([\d.]+)/ https://github.com/intel/libvpl.git|^2
 # bump: libvpl after ./hashupdate Dockerfile LIBVPL $LATEST
@@ -426,26 +394,6 @@ fetch_and_unpack twolame TWOLAME_VERSION TWOLAME_URL TWOLAME_SHA256
 ## Use 'libtheora' as name to match extracted directory
 #fetch_and_unpack libtheora THEORA_VERSION THEORA_URL THEORA_SHA256
 
-# bump: libssh /LIBSSH_VERSION=([\d.]+)/ https://gitlab.com/libssh/libssh-mirror.git|*
-# bump: libssh after ./hashupdate Dockerfile LIBSSH $LATEST
-# bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
-# bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-: "${LIBSSH_VERSION:=0.11.1}"
-: "${LIBSSH_URL:=https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz}"
-: "${LIBSSH_SHA256:=b43ef9c91b6c3db64e7ba3db101eb89dbe645db63489c19d4f88cf6f84911ec6}"
-# LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file (Build step comment)
-# Use 'libssh' as name, function expects dir 'libssh-${LIBSSH_VERSION}'
-fetch_and_unpack libssh LIBSSH_VERSION LIBSSH_URL LIBSSH_SHA256
-
-# bump: speex /SPEEX_VERSION=([\d.]+)/ https://github.com/xiph/speex.git|*
-# bump: speex after ./hashupdate Dockerfile SPEEX $LATEST
-# bump: speex link "ChangeLog" https://github.com/xiph/speex//blob/master/ChangeLog
-# bump: speex link "Source diff $CURRENT..$LATEST" https://github.com/xiph/speex/compare/$CURRENT..$LATEST
-: "${SPEEX_VERSION:=1.2.1}"
-: "${SPEEX_URL:=https://github.com/xiph/speex/archive/Speex-$SPEEX_VERSION.tar.gz}"
-: "${SPEEX_SHA256:=beaf2642e81a822eaade4d9ebf92e1678f301abfc74a29159c4e721ee70fdce0}"
-fetch_and_unpack speex SPEEX_VERSION SPEEX_URL SPEEX_SHA256
-
 # bump: libshine /LIBSHINE_VERSION=([\d.]+)/ https://github.com/toots/shine.git|*
 # bump: libshine after ./hashupdate Dockerfile LIBSHINE $LATEST
 # bump: libshine link "CHANGELOG" https://github.com/toots/shine/blob/master/ChangeLog
@@ -465,33 +413,6 @@ fetch_and_unpack shine LIBSHINE_VERSION LIBSHINE_URL LIBSHINE_SHA256
 : "${RUBBERBAND_SHA256:=b9eac027e797789ae99611c9eaeaf1c3a44cc804f9c8a0441a0d1d26f3d6bdf9}"
 fetch_and_unpack rubberband RUBBERBAND_VERSION RUBBERBAND_URL RUBBERBAND_SHA256
 
-# bump: librtmp /LIBRTMP_COMMIT=([[:xdigit:]]+)/ gitrefs:https://git.ffmpeg.org/rtmpdump.git|re:#^refs/heads/master$#|@commit
-# bump: librtmp after ./hashupdate Dockerfile LIBRTMP $LATEST
-# bump: librtmp link "Commit diff $CURRENT..$LATEST" https://git.ffmpeg.org/gitweb/rtmpdump.git/commitdiff/$LATEST?ds=sidebyside
-#: "${LIBRTMP_URL:=https://git.ffmpeg.org/rtmpdump.git}"
-#: "${LIBRTMP_COMMIT:=6f6bb1353fc84f4cc37138baa99f586750028a01}"
-## Use 'rtmpdump' as name to match cloned directory
-#fetch_and_unpack_git rtmpdump "" LIBRTMP_URL "" LIBRTMP_COMMIT
-
-
-# bump: librabbitmq /LIBRABBITMQ_VERSION=([\d.]+)/ https://github.com/alanxz/rabbitmq-c.git|*
-# bump: librabbitmq after ./hashupdate Dockerfile LIBRABBITMQ $LATEST
-# bump: librabbitmq link "ChangeLog" https://github.com/alanxz/rabbitmq-c/blob/master/ChangeLog.md
-: "${LIBRABBITMQ_VERSION:=0.15.0}"
-: "${LIBRABBITMQ_URL:=https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v$LIBRABBITMQ_VERSION.tar.gz}"
-: "${LIBRABBITMQ_SHA256:=7b652df52c0de4d19ca36c798ed81378cba7a03a0f0c5d498881ae2d79b241c2}"
-# Use 'rabbitmq-c' as name to match extracted directory
-fetch_and_unpack rabbitmq-c LIBRABBITMQ_VERSION LIBRABBITMQ_URL LIBRABBITMQ_SHA256
-
-# bump: opus /OPUS_VERSION=([\d.]+)/ https://github.com/xiph/opus.git|^1
-# bump: opus after ./hashupdate Dockerfile OPUS $LATEST
-# bump: opus link "Release notes" https://github.com/xiph/opus/releases/tag/v$LATEST
-# bump: opus link "Source diff $CURRENT..$LATEST" https://github.com/xiph/opus/compare/v$CURRENT..v$LATEST
-: "${OPUS_VERSION:=1.5.2}"
-: "${OPUS_URL:=https://downloads.xiph.org/releases/opus/opus-$OPUS_VERSION.tar.gz}"
-: "${OPUS_SHA256:=65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1}"
-fetch_and_unpack opus OPUS_VERSION OPUS_URL OPUS_SHA256
-
 # bump: openjpeg /OPENJPEG_VERSION=([\d.]+)/ https://github.com/uclouvain/openjpeg.git|*
 # bump: openjpeg after ./hashupdate Dockerfile OPENJPEG $LATEST
 # bump: openjpeg link "CHANGELOG" https://github.com/uclouvain/openjpeg/blob/master/CHANGELOG.md
@@ -499,15 +420,6 @@ fetch_and_unpack opus OPUS_VERSION OPUS_URL OPUS_SHA256
 : "${OPENJPEG_URL:=https://github.com/uclouvain/openjpeg/archive/v$OPENJPEG_VERSION.tar.gz}"
 : "${OPENJPEG_SHA256:=368fe0468228e767433c9ebdea82ad9d801a3ad1e4234421f352c8b06e7aa707}"
 fetch_and_unpack openjpeg OPENJPEG_VERSION OPENJPEG_URL OPENJPEG_SHA256
-
-# bump: opencoreamr /OPENCOREAMR_VERSION=([\d.]+)/ fetch:https://sourceforge.net/projects/opencore-amr/files/opencore-amr/|/opencore-amr-([\d.]+).tar.gz/
-# bump: opencoreamr after ./hashupdate Dockerfile OPENCOREAMR $LATEST
-# bump: opencoreamr link "ChangeLog" https://sourceforge.net/p/opencore-amr/code/ci/master/tree/ChangeLog
-: "${OPENCOREAMR_VERSION:=0.1.6}"
-: "${OPENCOREAMR_URL:=https://sourceforge.net/projects/opencore-amr/files/opencore-amr/opencore-amr-$OPENCOREAMR_VERSION.tar.gz}"
-: "${OPENCOREAMR_SHA256:=483eb4061088e2b34b358e47540b5d495a96cd468e361050fae615b1809dc4a1}"
-# Use 'opencore-amr' as name to match extracted directory
-fetch_and_unpack opencore-amr OPENCOREAMR_VERSION OPENCOREAMR_URL OPENCOREAMR_SHA256
 
 # bump: lcms2 /LCMS2_VERSION=([\d.]+)/ https://github.com/mm2/Little-CMS.git|^2
 # bump: lcms2 after ./hashupdate Dockerfile LCMS2 $LATEST
@@ -532,15 +444,6 @@ fetch_and_unpack lame MP3LAME_VERSION MP3LAME_URL MP3LAME_SHA256
 : "${LIBGSM_URL:=https://github.com/timothytylee/libgsm.git}"
 : "${LIBGSM_COMMIT:=98f1708fb5e06a0dfebd58a3b40d610823db9715}"
 fetch_and_unpack_git libgsm "" LIBGSM_URL "" LIBGSM_COMMIT
-
-# bump: fdk-aac /FDK_AAC_VERSION=([\d.]+)/ https://github.com/mstorsjo/fdk-aac.git|*
-# bump: fdk-aac after ./hashupdate Dockerfile FDK_AAC $LATEST
-# bump: fdk-aac link "ChangeLog" https://github.com/mstorsjo/fdk-aac/blob/master/ChangeLog
-# bump: fdk-aac link "Source diff $CURRENT..$LATEST" https://github.com/mstorsjo/fdk-aac/compare/v$CURRENT..v$LATEST
-: "${FDK_AAC_VERSION:=2.0.3}"
-: "${FDK_AAC_URL:=https://github.com/mstorsjo/fdk-aac/archive/v$FDK_AAC_VERSION.tar.gz}"
-: "${FDK_AAC_SHA256:=e25671cd96b10bad896aa42ab91a695a9e573395262baed4e4a2ff178d6a3a78}"
-fetch_and_unpack fdk-aac FDK_AAC_VERSION FDK_AAC_URL FDK_AAC_SHA256
 
 # bump: davs2 /DAVS2_VERSION=([\d.]+)/ https://github.com/pkuvcl/davs2.git|^1
 # bump: davs2 after ./hashupdate Dockerfile DAVS2 $LATEST

--- a/fetch-sources.sh
+++ b/fetch-sources.sh
@@ -17,7 +17,6 @@ fetch_and_unpack_git() {
   local name=$1
   local _unused_version_var=$2
   local url_var=$3
-  local _unused_sha256_var=${4:-}
   local commit_var=${5:-}
   local _unused_strip_components=${6:-0}
 
@@ -54,7 +53,6 @@ fetch_and_unpack() {
   local name=$1
   local version_var=$2
   local url_var=$3
-  local sha256_var=${4:-}
   local _unused_commit_var=${5:-}
   local strip_components=${6:-0}
 
@@ -64,7 +62,6 @@ fetch_and_unpack() {
 
   [[ -n "$version_var" && ${!version_var+x} ]] && version="${!version_var}"
   [[ -n "$url_var" && ${!url_var+x} ]] && url="${!url_var}"
-  [[ -n "$sha256_var" && ${!sha256_var+x} ]] && sha256="${!sha256_var}"
 
   if [[ -z "$url" ]]; then
     echo "Error: URL not set for $name"
@@ -103,8 +100,7 @@ fetch_and_unpack() {
 
 : "${SVTAV1_VERSION:=3.0.2}"
 : "${SVTAV1_URL:=https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v$SVTAV1_VERSION/SVT-AV1-v$SVTAV1_VERSION.tar.bz2}"
-: "${SVTAV1_SHA256:=7548a380cd58a46998ab4f1a02901ef72c37a7c6317c930cde5df2e6349e437b}"
-fetch_and_unpack SVT-AV1 SVTAV1_VERSION SVTAV1_URL SVTAV1_SHA256
+fetch_and_unpack SVT-AV1 SVTAV1_VERSION SVTAV1_URL
 
 # --- Library Definitions and Fetching ---
 
@@ -114,8 +110,7 @@ fetch_and_unpack SVT-AV1 SVTAV1_VERSION SVTAV1_URL SVTAV1_SHA256
 # bump: ffmpeg link "Source diff $CURRENT..$LATEST" https://github.com/FFmpeg/FFmpeg/compare/n$CURRENT..n$LATEST
 : "${FFMPEG_VERSION:=7.1.1}"
 : "${FFMPEG_URL:=https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.bz2}"
-: "${FFMPEG_SHA256:=0c8da2f11579a01e014fc007cbacf5bb4da1d06afd0b43c7f8097ec7c0f143ba}"
-fetch_and_unpack ffmpeg FFMPEG_VERSION FFMPEG_URL FFMPEG_SHA256
+fetch_and_unpack ffmpeg FFMPEG_VERSION FFMPEG_URL
 
 # bump: vorbis /VORBIS_VERSION=([\d.]+)/ https://github.com/xiph/vorbis.git|*
 # bump: vorbis after ./hashupdate Dockerfile VORBIS $LATEST
@@ -123,8 +118,7 @@ fetch_and_unpack ffmpeg FFMPEG_VERSION FFMPEG_URL FFMPEG_SHA256
 # bump: vorbis link "Source diff $CURRENT..$LATEST" https://github.com/xiph/vorbis/compare/v$CURRENT..v$LATEST
 : "${VORBIS_VERSION:=1.3.7}"
 : "${VORBIS_URL:=https://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz}"
-: "${VORBIS_SHA256:=0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab}"
-fetch_and_unpack libvorbis VORBIS_VERSION VORBIS_URL VORBIS_SHA256
+fetch_and_unpack libvorbis VORBIS_VERSION VORBIS_URL
 
 # bump: libvpx /VPX_VERSION=([\d.]+)/ https://github.com/webmproject/libvpx.git|*
 # bump: libvpx after ./hashupdate Dockerfile VPX $LATEST
@@ -132,8 +126,7 @@ fetch_and_unpack libvorbis VORBIS_VERSION VORBIS_URL VORBIS_SHA256
 # bump: libvpx link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libvpx/compare/v$CURRENT..v$LATEST
 : "${VPX_VERSION:=1.15.1}"
 : "${VPX_URL:=https://github.com/webmproject/libvpx/archive/v${VPX_VERSION}.tar.gz}"
-: "${VPX_SHA256:=6cba661b22a552bad729bd2b52df5f0d57d14b9789219d46d38f73c821d3a990}"
-fetch_and_unpack libvpx VPX_VERSION VPX_URL VPX_SHA256
+fetch_and_unpack libvpx VPX_VERSION VPX_URL
 
 # bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ https://github.com/webmproject/libwebp.git|^1
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
@@ -141,24 +134,21 @@ fetch_and_unpack libvpx VPX_VERSION VPX_URL VPX_SHA256
 # bump: libwebp link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libwebp/compare/v$CURRENT..v$LATEST
 : "${LIBWEBP_VERSION:=1.5.0}"
 : "${LIBWEBP_URL:=https://github.com/webmproject/libwebp/archive/v${LIBWEBP_VERSION}.tar.gz}"
-: "${LIBWEBP_SHA256:=668c9aba45565e24c27e17f7aaf7060a399f7f31dba6c97a044e1feacb930f37}"
-fetch_and_unpack libwebp LIBWEBP_VERSION LIBWEBP_URL LIBWEBP_SHA256
+fetch_and_unpack libwebp LIBWEBP_VERSION LIBWEBP_URL
 
 # bump: libva /LIBVA_VERSION=([\d.]+)/ https://github.com/intel/libva.git|^2
 # bump: libva after ./hashupdate Dockerfile LIBVA $LATEST
 # bump: libva link "Changelog" https://github.com/intel/libva/blob/master/NEWS
 : "${LIBVA_VERSION:=2.22.0}"
 : "${LIBVA_URL:=https://github.com/intel/libva/archive/refs/tags/${LIBVA_VERSION}.tar.gz}"
-: "${LIBVA_SHA256:=467c418c2640a178c6baad5be2e00d569842123763b80507721ab87eb7af8735}"
-fetch_and_unpack libva LIBVA_VERSION LIBVA_URL LIBVA_SHA256
+fetch_and_unpack libva LIBVA_VERSION LIBVA_URL
 
 # bump: srt /SRT_VERSION=([\d.]+)/ https://github.com/Haivision/srt.git|^1
 # bump: srt after ./hashupdate Dockerfile SRT $LATEST
 # bump: srt link "Release notes" https://github.com/Haivision/srt/releases/tag/v$LATEST
 : "${SRT_VERSION:=1.5.4}"
 : "${SRT_URL:=https://github.com/Haivision/srt/archive/v${SRT_VERSION}.tar.gz}"
-: "${SRT_SHA256:=d0a8b600fe1b4eaaf6277530e3cfc8f15b8ce4035f16af4a5eb5d4b123640cdd}"
-fetch_and_unpack srt SRT_VERSION SRT_URL SRT_SHA256
+fetch_and_unpack srt SRT_VERSION SRT_URL
 
 # bump: ogg /OGG_VERSION=([\d.]+)/ https://github.com/xiph/ogg.git|*
 # bump: ogg after ./hashupdate Dockerfile OGG $LATEST
@@ -175,8 +165,7 @@ fetch_and_unpack srt SRT_VERSION SRT_URL SRT_SHA256
 # bump: zimg link "ChangeLog" https://github.com/sekrit-twc/zimg/blob/master/ChangeLog
 : "${ZIMG_VERSION:=3.0.5}"
 : "${ZIMG_URL:=https://github.com/sekrit-twc/zimg/archive/release-${ZIMG_VERSION}.tar.gz}"
-: "${ZIMG_SHA256:=a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf}"
-fetch_and_unpack zimg ZIMG_VERSION ZIMG_URL ZIMG_SHA256
+fetch_and_unpack zimg ZIMG_VERSION ZIMG_URL
 
 # preferring rav1e-static rav1e-dev from apk (0.7.1)
 # bump: rav1e /RAV1E_VERSION=([\d.]+)/ https://github.com/xiph/rav1e.git|/\d+\./|*
@@ -193,8 +182,7 @@ fetch_and_unpack zimg ZIMG_VERSION ZIMG_URL ZIMG_SHA256
 # bump: vorbis link "Source diff $CURRENT..$LATEST" https://github.com/xiph/vorbis/compare/v$CURRENT..v$LATEST
 : "${VORBIS_VERSION:=1.3.7}"
 : "${VORBIS_URL:=https://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz}"
-: "${VORBIS_SHA256:=0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab}"
-fetch_and_unpack libvorbis VORBIS_VERSION VORBIS_URL VORBIS_SHA256
+fetch_and_unpack libvorbis VORBIS_VERSION VORBIS_URL
 
 # bump: libvpx /VPX_VERSION=([\d.]+)/ https://github.com/webmproject/libvpx.git|*
 # bump: libvpx after ./hashupdate Dockerfile VPX $LATEST
@@ -202,8 +190,7 @@ fetch_and_unpack libvorbis VORBIS_VERSION VORBIS_URL VORBIS_SHA256
 # bump: libvpx link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libvpx/compare/v$CURRENT..v$LATEST
 : "${VPX_VERSION:=1.15.1}"
 : "${VPX_URL:=https://github.com/webmproject/libvpx/archive/v${VPX_VERSION}.tar.gz}"
-: "${VPX_SHA256:=6cba661b22a552bad729bd2b52df5f0d57d14b9789219d46d38f73c821d3a990}"
-fetch_and_unpack libvpx VPX_VERSION VPX_URL VPX_SHA256
+fetch_and_unpack libvpx VPX_VERSION VPX_URL
 
 # bump: libwebp /LIBWEBP_VERSION=([\d.]+)/ https://github.com/webmproject/libwebp.git|^1
 # bump: libwebp after ./hashupdate Dockerfile LIBWEBP $LATEST
@@ -211,24 +198,21 @@ fetch_and_unpack libvpx VPX_VERSION VPX_URL VPX_SHA256
 # bump: libwebp link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libwebp/compare/v$CURRENT..v$LATEST
 : "${LIBWEBP_VERSION:=1.5.0}"
 : "${LIBWEBP_URL:=https://github.com/webmproject/libwebp/archive/v${LIBWEBP_VERSION}.tar.gz}"
-: "${LIBWEBP_SHA256:=668c9aba45565e24c27e17f7aaf7060a399f7f31dba6c97a044e1feacb930f37}"
-fetch_and_unpack libwebp LIBWEBP_VERSION LIBWEBP_URL LIBWEBP_SHA256
+fetch_and_unpack libwebp LIBWEBP_VERSION LIBWEBP_URL
 
 # bump: librsvg /LIBRSVG_VERSION=([\d.]+)/ https://gitlab.gnome.org/GNOME/librsvg.git|^2
 # bump: librsvg after ./hashupdate Dockerfile LIBRSVG $LATEST
 # bump: librsvg link "NEWS" https://gitlab.gnome.org/GNOME/librsvg/-/blob/master/NEWS
 : "${LIBRSVG_VERSION:=2.60.0}"
 : "${LIBRSVG_URL:=https://download.gnome.org/sources/librsvg/2.60/librsvg-$LIBRSVG_VERSION.tar.xz}"
-: "${LIBRSVG_SHA256:=0b6ffccdf6e70afc9876882f5d2ce9ffcf2c713cbaaf1ad90170daa752e1eec3}"
-fetch_and_unpack librsvg LIBRSVG_VERSION LIBRSVG_URL LIBRSVG_SHA256
+fetch_and_unpack librsvg LIBRSVG_VERSION LIBRSVG_URL
 
 # bump: dav1d /DAV1D_VERSION=([\d.]+)/ https://code.videolan.org/videolan/dav1d.git|*
 # bump: dav1d after ./hashupdate Dockerfile DAV1D $LATEST
 # bump: dav1d link "Release notes" https://code.videolan.org/videolan/dav1d/-/tags/$LATEST
 : "${DAV1D_VERSION:=1.5.1}"
 : "${DAV1D_URL:=https://code.videolan.org/videolan/dav1d/-/archive/$DAV1D_VERSION/dav1d-$DAV1D_VERSION.tar.gz}"
-: "${DAV1D_SHA256:=fa635e2bdb25147b1384007c83e15de44c589582bb3b9a53fc1579cb9d74b695}"
-fetch_and_unpack dav1d DAV1D_VERSION DAV1D_URL DAV1D_SHA256
+fetch_and_unpack dav1d DAV1D_VERSION DAV1D_URL
 
 # preferring glib-static glib-dev from apk (2.84.1)
 # own build as alpine glib links with libmount etc
@@ -245,25 +229,14 @@ fetch_and_unpack dav1d DAV1D_VERSION DAV1D_URL DAV1D_SHA256
 # bump: libbluray link "ChangeLog" https://code.videolan.org/videolan/libbluray/-/blob/master/ChangeLog
 : "${LIBBLURAY_VERSION:=1.3.4}"
 : "${LIBBLURAY_URL:=https://code.videolan.org/videolan/libbluray/-/archive/$LIBBLURAY_VERSION/libbluray-$LIBBLURAY_VERSION.tar.gz}"
-: "${LIBBLURAY_SHA256:=9820df5c3e87777be116ca225ad7ee026a3ff42b2447c7fe641910fb23aad3c2}"
-: "${LIBUDFREAD_COMMIT:=a35513813819efadca82c4b90edbe1407b1b9e05}"
-fetch_and_unpack libbluray LIBBLURAY_VERSION LIBBLURAY_URL LIBBLURAY_SHA256
-
-# bump: libass /LIBASS_VERSION=([\d.]+)/ https://github.com/libass/libass.git|*
-# bump: libass after ./hashupdate Dockerfile LIBASS $LATEST
-# bump: libass link "Release notes" https://github.com/libass/libass/releases/tag/$LATEST
-: "${LIBASS_VERSION:=0.17.3}"
-: "${LIBASS_URL:=https://github.com/libass/libass/releases/download/$LIBASS_VERSION/libass-$LIBASS_VERSION.tar.gz}"
-: "${LIBASS_SHA256:=da7c348deb6fa6c24507afab2dee7545ba5dd5bbf90a137bfe9e738f7df68537}"
-fetch_and_unpack libass LIBASS_VERSION LIBASS_URL LIBASS_SHA256
+fetch_and_unpack libbluray LIBBLURAY_VERSION LIBBLURAY_URL
 
 # bump: libvpl /LIBVPL_VERSION=([\d.]+)/ https://github.com/intel/libvpl.git|^2
 # bump: libvpl after ./hashupdate Dockerfile LIBVPL $LATEST
 # bump: libvpl link "Changelog" https://github.com/intel/libvpl/blob/main/CHANGELOG.md
 : "${LIBVPL_VERSION:=2.14.0}"
 : "${LIBVPL_URL:=https://github.com/intel/libvpl/archive/refs/tags/v${LIBVPL_VERSION}.tar.gz}"
-: "${LIBVPL_SHA256:=7c6bff1c1708d910032c2e6c44998ffff3f5fdbf06b00972bc48bf2dd9e5ac06}"
-fetch_and_unpack libvpl LIBVPL_VERSION LIBVPL_URL LIBVPL_SHA256
+fetch_and_unpack libvpl LIBVPL_VERSION LIBVPL_URL
 
 # bump: libjxl /LIBJXL_VERSION=([\d.]+)/ https://github.com/libjxl/libjxl.git|^0
 # bump: libjxl after ./hashupdate Dockerfile LIBJXL $LATEST
@@ -271,8 +244,7 @@ fetch_and_unpack libvpl LIBVPL_VERSION LIBVPL_URL LIBVPL_SHA256
 # use bundled highway library as its static build is not available in alpine
 : "${LIBJXL_VERSION:=0.11.1}"
 : "${LIBJXL_URL:=https://github.com/libjxl/libjxl/archive/refs/tags/v${LIBJXL_VERSION}.tar.gz}"
-: "${LIBJXL_SHA256:=1492dfef8dd6c3036446ac3b340005d92ab92f7d48ee3271b5dac1d36945d3d9}"
-fetch_and_unpack libjxl LIBJXL_VERSION LIBJXL_URL LIBJXL_SHA256
+fetch_and_unpack libjxl LIBJXL_VERSION LIBJXL_URL
 
 
 # bump: xevd /XEVD_VERSION=([\d.]+)/ https://github.com/mpeg5/xevd.git|*
@@ -282,8 +254,7 @@ fetch_and_unpack libjxl LIBJXL_VERSION LIBJXL_URL LIBJXL_SHA256
 # TODO: report upstream about lib/libxevd.a?
 : "${XEVD_VERSION:=0.5.0}"
 : "${XEVD_URL:=https://github.com/mpeg5/xevd/archive/refs/tags/v$XEVD_VERSION.tar.gz}"
-: "${XEVD_SHA256:=8d55c7ec1a9ad4e70fe91fbe129a1d4dd288bce766f466cba07a29452b3cecd8}"
-fetch_and_unpack xevd XEVD_VERSION XEVD_URL XEVD_SHA256
+fetch_and_unpack xevd XEVD_VERSION XEVD_URL
 # Custom step for xevd: create version.txt
 if [[ -d "xevd-${XEVD_VERSION}" ]]; then
   echo "Running custom steps for xevd..."
@@ -300,8 +271,7 @@ fi
 # TODO: report upstream about lib/libxeve.a?
 : "${XEVE_VERSION:=0.5.1}"
 : "${XEVE_URL:=https://github.com/mpeg5/xeve/archive/refs/tags/v$XEVE_VERSION.tar.gz}"
-: "${XEVE_SHA256:=238c95ddd1a63105913d9354045eb329ad9002903a407b5cf1ab16bad324c245}"
-fetch_and_unpack xeve XEVE_VERSION XEVE_URL XEVE_SHA256
+fetch_and_unpack xeve XEVE_VERSION XEVE_URL
 # Custom step for xeve: create version.txt
 if [[ -d "xeve-${XEVE_VERSION}" ]]; then
   echo "Running custom steps for xeve..."
@@ -318,11 +288,9 @@ fi
 # bump: xavs2 link "Source diff $CURRENT..$LATEST" https://github.com/pkuvcl/xavs2/compare/v$CURRENT..v$LATEST
 #XAVS2_VERSION=1.4
 #XAVS2_URL="https://github.com/pkuvcl/xavs2/archive/refs/tags/$XAVS2_VERSION.tar.gz"
-#XAVS2_SHA256=1e6d731cd64cb2a8940a0a3fd24f9c2ac3bb39357d802432a47bc20bad52c6ce
 #: "${XAVS2_VERSION:=1.4}"
 #: "${XAVS2_URL:=https://github.com/pkuvcl/xavs2/archive/refs/tags/$XAVS2_VERSION.tar.gz}"
-#: "${XAVS2_SHA256:=1e6d731cd64cb2a8940a0a3fd24f9c2ac3bb39357d802432a47bc20bad52c6ce}"
-#fetch_and_unpack xavs2 XAVS2_VERSION XAVS2_URL XAVS2_SHA256
+#fetch_and_unpack xavs2 XAVS2_VERSION XAVS2_URL
 
 # http://websvn.xvid.org/cvs/viewvc.cgi/trunk/xvidcore/build/generic/configure.in?revision=2146&view=markup
 # bump: xvid /XVID_VERSION=([\d.]+)/ svn:https://anonymous:@svn.xvid.org|/^release-(.*)$/|/_/./|^1
@@ -342,11 +310,10 @@ fi
 # NOTE: Original script saved this as .tar.bz2 and checked SHA against that name.
 # The URL points to a .tar.gz file. Using the .tar.gz URL.
 # The SHA provided might be for the .tar.bz2 and could fail verification against the .tar.gz.
-: "${X265_SHA256:=75b4d05629e365913de3100b38a459b04e2a217a8f30efaa91b572d8e6d71282}"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh
 # Use 'x265' as name, function expects dir 'x265-${X265_VERSION}'
-fetch_and_unpack x265 X265_VERSION X265_URL X265_SHA256
+fetch_and_unpack x265 X265_VERSION X265_URL
 
 # x264 only have a stable branch no tags and we checkout commit so no hash is needed
 # bump: x264 /X264_VERSION=([[:xdigit:]]+)/ gitrefs:https://code.videolan.org/videolan/x264.git|re:#^refs/heads/stable$#|@commit
@@ -362,9 +329,8 @@ fetch_and_unpack_git x264 "" X264_URL "" X264_COMMIT
 # bump: vid.stab link "Changelog" https://github.com/georgmartius/vid.stab/blob/master/Changelog
 : "${VIDSTAB_VERSION:=1.1.1}"
 : "${VIDSTAB_URL:=https://github.com/georgmartius/vid.stab/archive/v$VIDSTAB_VERSION.tar.gz}"
-: "${VIDSTAB_SHA256:=9001b6df73933555e56deac19a0f225aae152abbc0e97dc70034814a1943f3d4}"
 # Use 'vid.stab' as name, function expects dir 'vid.stab-${VIDSTAB_VERSION}'
-fetch_and_unpack vid.stab VIDSTAB_VERSION VIDSTAB_URL VIDSTAB_SHA256
+fetch_and_unpack vid.stab VIDSTAB_VERSION VIDSTAB_URL
 
 # bump: uavs3d /UAVS3D_COMMIT=([[:xdigit:]]+)/ gitrefs:https://github.com/uavs3/uavs3d.git|re:#^refs/heads/master$#|@commit
 # bump: uavs3d after ./hashupdate Dockerfile UAVS3D $LATEST
@@ -379,8 +345,7 @@ fetch_and_unpack_git uavs3d "" UAVS3D_URL "" UAVS3D_COMMIT
 # bump: twolame link "Source diff $CURRENT..$LATEST" https://github.com/njh/twolame/compare/v$CURRENT..v$LATEST
 : "${TWOLAME_VERSION:=0.4.0}"
 : "${TWOLAME_URL:=https://github.com/njh/twolame/releases/download/$TWOLAME_VERSION/twolame-$TWOLAME_VERSION.tar.gz}"
-: "${TWOLAME_SHA256:=cc35424f6019a88c6f52570b63e1baf50f62963a3eac52a03a800bb070d7c87d}"
-fetch_and_unpack twolame TWOLAME_VERSION TWOLAME_URL TWOLAME_SHA256
+fetch_and_unpack twolame TWOLAME_VERSION TWOLAME_URL
 
 # bump: theora /THEORA_VERSION=([\d.]+)/ https://github.com/xiph/theora.git|*
 # bump: theora after ./hashupdate Dockerfile THEORA $LATEST
@@ -390,9 +355,8 @@ fetch_and_unpack twolame TWOLAME_VERSION TWOLAME_URL TWOLAME_SHA256
 #: "${THEORA_URL:=http://downloads.xiph.org/releases/theora/libtheora-$THEORA_VERSION.tar.gz}"
 ## NOTE: Original script saved this as .tar.bz2. URL is .tar.gz. Using .tar.gz URL.
 ## Provided SHA might be for the .tar.bz2 and could fail verification.
-#: "${THEORA_SHA256:=279327339903b544c28a92aeada7d0dcfd0397b59c2f368cc698ac56f515906e}"
 ## Use 'libtheora' as name to match extracted directory
-#fetch_and_unpack libtheora THEORA_VERSION THEORA_URL THEORA_SHA256
+#fetch_and_unpack libtheora THEORA_VERSION THEORA_URL
 
 # bump: libshine /LIBSHINE_VERSION=([\d.]+)/ https://github.com/toots/shine.git|*
 # bump: libshine after ./hashupdate Dockerfile LIBSHINE $LATEST
@@ -400,9 +364,8 @@ fetch_and_unpack twolame TWOLAME_VERSION TWOLAME_URL TWOLAME_SHA256
 # bump: libshine link "Source diff $CURRENT..$LATEST" https://github.com/toots/shine/compare/$CURRENT..$LATEST
 : "${LIBSHINE_VERSION:=3.1.1}"
 : "${LIBSHINE_URL:=https://github.com/toots/shine/releases/download/$LIBSHINE_VERSION/shine-$LIBSHINE_VERSION.tar.gz}"
-: "${LIBSHINE_SHA256:=58e61e70128cf73f88635db495bfc17f0dde3ce9c9ac070d505a0cd75b93d384}"
 # Use 'shine' as name to match extracted directory
-fetch_and_unpack shine LIBSHINE_VERSION LIBSHINE_URL LIBSHINE_SHA256
+fetch_and_unpack shine LIBSHINE_VERSION LIBSHINE_URL
 
 # bump: rubberband /RUBBERBAND_VERSION=([\d.]+)/ https://github.com/breakfastquay/rubberband.git|^2
 # bump: rubberband after ./hashupdate Dockerfile RUBBERBAND $LATEST
@@ -410,33 +373,29 @@ fetch_and_unpack shine LIBSHINE_VERSION LIBSHINE_URL LIBSHINE_SHA256
 # bump: rubberband link "Source diff $CURRENT..$LATEST" https://github.com/breakfastquay/rubberband/compare/$CURRENT..$LATEST
 : "${RUBBERBAND_VERSION:=2.0.2}"
 : "${RUBBERBAND_URL:=https://breakfastquay.com/files/releases/rubberband-$RUBBERBAND_VERSION.tar.bz2}"
-: "${RUBBERBAND_SHA256:=b9eac027e797789ae99611c9eaeaf1c3a44cc804f9c8a0441a0d1d26f3d6bdf9}"
-fetch_and_unpack rubberband RUBBERBAND_VERSION RUBBERBAND_URL RUBBERBAND_SHA256
+fetch_and_unpack rubberband RUBBERBAND_VERSION RUBBERBAND_URL
 
 # bump: openjpeg /OPENJPEG_VERSION=([\d.]+)/ https://github.com/uclouvain/openjpeg.git|*
 # bump: openjpeg after ./hashupdate Dockerfile OPENJPEG $LATEST
 # bump: openjpeg link "CHANGELOG" https://github.com/uclouvain/openjpeg/blob/master/CHANGELOG.md
 : "${OPENJPEG_VERSION:=2.5.3}"
 : "${OPENJPEG_URL:=https://github.com/uclouvain/openjpeg/archive/v$OPENJPEG_VERSION.tar.gz}"
-: "${OPENJPEG_SHA256:=368fe0468228e767433c9ebdea82ad9d801a3ad1e4234421f352c8b06e7aa707}"
-fetch_and_unpack openjpeg OPENJPEG_VERSION OPENJPEG_URL OPENJPEG_SHA256
+fetch_and_unpack openjpeg OPENJPEG_VERSION OPENJPEG_URL
 
 # bump: lcms2 /LCMS2_VERSION=([\d.]+)/ https://github.com/mm2/Little-CMS.git|^2
 # bump: lcms2 after ./hashupdate Dockerfile LCMS2 $LATEST
 # bump: lcms2 link "Release" https://github.com/mm2/Little-CMS/releases/tag/lcms$LATEST
 : "${LCMS2_VERSION:=2.17}"
 : "${LCMS2_URL:=https://github.com/mm2/Little-CMS/releases/download/lcms$LCMS2_VERSION/lcms2-$LCMS2_VERSION.tar.gz}"
-: "${LCMS2_SHA256:=d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074}"
-fetch_and_unpack lcms2 LCMS2_VERSION LCMS2_URL LCMS2_SHA256
+fetch_and_unpack lcms2 LCMS2_VERSION LCMS2_URL
 
 # bump: mp3lame /MP3LAME_VERSION=([\d.]+)/ svn:http://svn.code.sf.net/p/lame/svn|/^RELEASE__(.*)$/|/_/./|*
 # bump: mp3lame after ./hashupdate Dockerfile MP3LAME $LATEST
 # bump: mp3lame link "ChangeLog" http://svn.code.sf.net/p/lame/svn/trunk/lame/ChangeLog
 : "${MP3LAME_VERSION:=3.100}"
 : "${MP3LAME_URL:=https://sourceforge.net/projects/lame/files/lame/$MP3LAME_VERSION/lame-$MP3LAME_VERSION.tar.gz/download}"
-: "${MP3LAME_SHA256:=ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e}"
 # Use 'lame' as name to match extracted directory
-fetch_and_unpack lame MP3LAME_VERSION MP3LAME_URL MP3LAME_SHA256
+fetch_and_unpack lame MP3LAME_VERSION MP3LAME_URL
 
 # bump: libgsm /LIBGSM_COMMIT=([[:xdigit:]]+)/ gitrefs:https://github.com/timothytylee/libgsm.git|re:#^refs/heads/master$#|@commit
 # bump: libgsm after ./hashupdate Dockerfile LIBGSM $LATEST
@@ -451,8 +410,7 @@ fetch_and_unpack_git libgsm "" LIBGSM_URL "" LIBGSM_COMMIT
 # bump: davs2 link "Source diff $CURRENT..$LATEST" https://github.com/pkuvcl/davs2/compare/v$CURRENT..v$LATEST
 : "${DAVS2_VERSION:=1.7}"
 : "${DAVS2_URL:=https://github.com/pkuvcl/davs2/archive/refs/tags/$DAVS2_VERSION.tar.gz}"
-: "${DAVS2_SHA256:=b697d0b376a1c7f7eda3a4cc6d29707c8154c4774358303653f0a9727f923cc8}"
-fetch_and_unpack davs2 DAVS2_VERSION DAVS2_URL DAVS2_SHA256
+fetch_and_unpack davs2 DAVS2_VERSION DAVS2_URL
 
 # build after libvmaf
 # bump: aom /AOM_VERSION=([\d.]+)/ git:https://aomedia.googlesource.com/aom|*
@@ -470,8 +428,7 @@ git clone --depth 1 --branch v$AOM_VERSION "$AOM_URL" && cd aom && test $(git re
 # bump: harfbuzz link "NEWS" https://github.com/harfbuzz/harfbuzz/blob/main/NEWS
 : "${LIBHARFBUZZ_VERSION:=11.2.0}"
 : "${LIBHARFBUZZ_URL:=https://github.com/harfbuzz/harfbuzz/releases/download/$LIBHARFBUZZ_VERSION/harfbuzz-$LIBHARFBUZZ_VERSION.tar.xz}"
-: "${LIBHARFBUZZ_SHA256:=50f7d0a208367e606dbf6eecc5cfbecc01a47be6ee837ae7aff2787e24b09b45}"
-fetch_and_unpack harfbuzz LIBHARFBUZZ_VERSION LIBHARFBUZZ_URL LIBHARFBUZZ_SHA256
+fetch_and_unpack harfbuzz LIBHARFBUZZ_VERSION LIBHARFBUZZ_URL
 
 
 # bump: vmaf /VMAF_VERSION=([\d.]+)/ https://github.com/Netflix/vmaf.git|*
@@ -480,24 +437,21 @@ fetch_and_unpack harfbuzz LIBHARFBUZZ_VERSION LIBHARFBUZZ_URL LIBHARFBUZZ_SHA256
 # bump: vmaf link "Source diff $CURRENT..$LATEST" https://github.com/Netflix/vmaf/compare/v$CURRENT..v$LATEST
 : "${VMAF_VERSION:=3.0.0}"
 : "${VMAF_URL:=https://github.com/Netflix/vmaf/archive/refs/tags/v$VMAF_VERSION.tar.gz}"
-: "${VMAF_SHA256:=7178c4833639e6b989ecae73131d02f70735fdb3fc2c7d84bc36c9c3461d93b1}"
-fetch_and_unpack vmaf VMAF_VERSION VMAF_URL VMAF_SHA256
+fetch_and_unpack vmaf VMAF_VERSION VMAF_URL
 
 # bump: vvenc /VVENC_VERSION=([\d.]+)/ https://github.com/fraunhoferhhi/vvenc.git|*
 # bump: vvenc after ./hashupdate Dockerfile VVENC $LATEST
 # bump: vvenc link "CHANGELOG" https://github.com/fraunhoferhhi/vvenc/releases/tag/v$LATEST
 : "${VVENC_VERSION:=1.13.1}"
 : "${VVENC_URL:=https://github.com/fraunhoferhhi/vvenc/archive/refs/tags/v$VVENC_VERSION.tar.gz}"
-: "${VVENC_SHA256:=9d0d88319b9c200ebf428471a3f042ea7dcd868e8be096c66e19120a671a0bc8}"
-fetch_and_unpack vvenc VVENC_VERSION VVENC_URL VVENC_SHA256
+fetch_and_unpack vvenc VVENC_VERSION VVENC_URL
 
 # bump: cairo /CAIRO_VERSION=([\d.]+)/ https://gitlab.freedesktop.org/cairo/cairo.git|^1
 # bump: cairo after ./hashupdate Dockerfile CAIRO $LATEST
 # bump: cairo link "NEWS" https://gitlab.freedesktop.org/cairo/cairo/-/blob/master/NEWS?ref_type=heads
-#: "${CAIRO_VERSION:=1.18.4}"
-#: "${CAIRO_URL:=https://cairographics.org/releases/cairo-$CAIRO_VERSION.tar.xz}"
-#: "${CAIRO_SHA256:=445ed8208a6e4823de1226a74ca319d3600e83f6369f99b14265006599c32ccb}"
-#fetch_and_unpack cairo CAIRO_VERSION CAIRO_URL CAIRO_SHA256
+: "${CAIRO_VERSION:=1.18.4}"
+: "${CAIRO_URL:=https://cairographics.org/releases/cairo-$CAIRO_VERSION.tar.xz}"
+fetch_and_unpack cairo CAIRO_VERSION CAIRO_URL
 
 # TODO: there is weird "1.90" tag, skip it
 # bump: pango /PANGO_VERSION=([\d.]+)/ https://github.com/GNOME/pango.git|/\d+\.\d+\.\d+/|*
@@ -505,10 +459,9 @@ fetch_and_unpack vvenc VVENC_VERSION VVENC_URL VVENC_SHA256
 # bump: pango link "NEWS" https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads
 : "${PANGO_VERSION:=1.56.3}"
 : "${PANGO_URL:=https://download.gnome.org/sources/pango/1.56/pango-$PANGO_VERSION.tar.xz}"
-: "${PANGO_SHA256=2606252bc25cd8d24e1b7f7e92c3a272b37acd6734347b73b47a482834ba2491}"
 # TODO: add -Dbuild-testsuite=false when in stable release
 # TODO: -Ddefault_library=both currently to not fail building tests
-fetch_and_unpack pango PANGO_VERSION PANGO_URL PANGO_SHA256
+fetch_and_unpack pango PANGO_VERSION PANGO_URL
 
 # bump: libmysofa /LIBMYSOFA_VERSION=([\d.]+)/ https://github.com/hoene/libmysofa.git|^1
 # bump: libmysofa after ./hashupdate Dockerfile LIBMYSOFA $LATEST
@@ -516,8 +469,14 @@ fetch_and_unpack pango PANGO_VERSION PANGO_URL PANGO_SHA256
 # bump: libmysofa link "Source diff $CURRENT..$LATEST" https://github.com/hoene/libmysofa/compare/v$CURRENT..v$LATEST
 : "${LIBMYSOFA_VERSION:=1.3.3}"
 : "${LIBMYSOFA_URL:=https://github.com/hoene/libmysofa/archive/refs/tags/v$LIBMYSOFA_VERSION.tar.gz}"
-: "${LIBMYSOFA_SHA256=a15f7236a2b492f8d8da69f6c71b5bde1ef1bac0ef428b94dfca1cabcb24c84f}"
-fetch_and_unpack libmysofa LIBMYSOFA_VERSION LIBMYSOFA_URL LIBMYSOFA_SHA256
+fetch_and_unpack libmysofa LIBMYSOFA_VERSION LIBMYSOFA_URL
+
+# bump: libass /LIBASS_VERSION=([\d.]+)/ https://github.com/libass/libass.git|*
+# bump: libass after ./hashupdate Dockerfile LIBASS $LATEST
+# bump: libass link "Release notes" https://github.com/libass/libass/releases/tag/$LATEST
+: "${LIBASS_VERSION:=0.17.4}"
+: "${LIBASS_URL:=https://github.com/libass/libass/releases/download/$LIBASS_VERSION/libass-$LIBASS_VERSION.tar.gz}"
+fetch_and_unpack libass LIBASS_VERSION LIBASS_URL
 
 echo "All fetching and unpacking complete."
 


### PR DESCRIPTION
### Summary

This PR overhauls our FFmpeg build configuration to enhance capabilities, add modern features, and remove redundant or unnecessary dependencies. Key changes include adding support for Vulkan and `libplacebo` for high-performance, GPU-accelerated video processing.

We have also enabled several important libraries for subtitle rendering, audio processing, and broader format compatibility. Finally, we have removed a number of external libraries in favor of FFmpeg's high-quality native encoders or to simplify the build by eliminating niche and redundant components.

### New Dependencies & Features

This build now includes support for the following major features:

* **Vulkan (`--enable-vulkan`)**: Adds support for the modern, cross-platform GPU acceleration API. This enables fully GPU-powered pipelines for decoding, filtering, and encoding, providing a significant performance uplift and future-proofing our build.

### Enabled Existing Features

The following libraries are now enabled in the build to provide broader format support and critical functionality:

* **Subtitle and Text Rendering**:
    * `--enable-libass`: Enables rendering of styled Advanced SubStation Alpha (`.ass`) subtitles, a standard for subtitle burn-in.
    * `--enable-libfreetype`: Provides the core font rendering engine required by `libass` and the `drawtext` filter.
    * `--enable-libfribidi`: Ensures correct rendering of bidirectional text (e.g., Arabic, Hebrew).
    * `--enable-libharfbuzz`: Adds advanced text shaping for proper layout of complex scripts.

* **Audio Processing**:
    * `--enable-libsoxr`: Provides a high-quality audio resampling library for professional workflows.
    * `--enable-libmysofa`: Enables the `sofalizer` filter for processing 3D and immersive binaural audio.
    * `--enable-libtwolame`: Adds an MPEG Audio Layer 2 (MP2) encoder, which is important for digital broadcast workflows (DVB/DAB).

* **Video and Image Utilities**:
    * `--enable-libvidstab`: Enables video stabilization filters to correct shaky footage.

### Removed Dependencies

The following libraries have been removed from the build to streamline dependencies and rely on FFmpeg's robust native components:

| Library             | Justification for Removal                                                                                                                              |
| :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
| **fdk-aac** | FFmpeg’s native AAC encoder is now stable and considered high-quality, making the external `libfdk-aac` unnecessary for most use cases.                  |
| **opus** | FFmpeg 3.3 introduced a native Opus encoder, complementing the existing native decoder and eliminating the need for the external `libopus`.              |
| **speex** | FFmpeg 5.0 added a native Speex decoder, making the external library redundant for decoding tasks.                                                     |
| **lame** | The native FFmpeg MP3 encoder is sufficient for many use cases, and removing `libmp3lame` simplifies the build.                                         |
| **kvazaar** | This HEVC encoder is redundant, as the build already includes the more mature and widely used `libx265`.                                                |
| **Networking Libs** | Removed specialized networking libraries (`rabbitmq-c`, `rtmpdump`, `libssh`, `srt`, `zeromq`) to reduce complexity.                                    |
| **Specialized Audio** | Removed niche audio format libraries (`opencore-amr`, `game-music-emu`, `libmodplug`) that are not required for general transcoding workflows. |